### PR TITLE
Add ability to set border radius of floating widget.

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,1 +1,2 @@
 const defaultAnimationDuration = Duration(milliseconds: 200);
+const double defaultFloatingBorderRadius = 10;

--- a/lib/src/pip_view.dart
+++ b/lib/src/pip_view.dart
@@ -7,6 +7,7 @@ class PIPView extends StatefulWidget {
   final PIPViewCorner initialCorner;
   final double? floatingWidth;
   final double? floatingHeight;
+  final double? floatingBorderRadius;
   final bool avoidKeyboard;
 
   final Widget Function(
@@ -20,6 +21,7 @@ class PIPView extends StatefulWidget {
     this.initialCorner = PIPViewCorner.topRight,
     this.floatingWidth,
     this.floatingHeight,
+    this.floatingBorderRadius,
     this.avoidKeyboard = true,
   }) : super(key: key);
 
@@ -65,6 +67,7 @@ class PIPViewState extends State<PIPView> with TickerProviderStateMixin {
       ),
       floatingHeight: widget.floatingHeight,
       floatingWidth: widget.floatingWidth,
+      floatingBorderRadius: widget.floatingBorderRadius,
       initialCorner: widget.initialCorner,
     );
   }

--- a/lib/src/raw_pip_view.dart
+++ b/lib/src/raw_pip_view.dart
@@ -6,6 +6,7 @@ class RawPIPView extends StatefulWidget {
   final PIPViewCorner initialCorner;
   final double? floatingWidth;
   final double? floatingHeight;
+  final double? floatingBorderRadius;
   final bool avoidKeyboard;
   final Widget? topWidget;
   final Widget? bottomWidget;
@@ -20,11 +21,14 @@ class RawPIPView extends StatefulWidget {
     this.initialCorner = PIPViewCorner.topRight,
     this.floatingWidth,
     this.floatingHeight,
+    double? floatingBorderRadius,
     this.avoidKeyboard = true,
     this.topWidget,
     this.bottomWidget,
     this.onTapTopWidget,
-  }) : super(key: key);
+  }) :
+        this.floatingBorderRadius = floatingBorderRadius ?? defaultFloatingBorderRadius,
+        super(key: key);
 
   @override
   RawPIPViewState createState() => RawPIPViewState();
@@ -200,14 +204,14 @@ class RawPIPViewState extends State<RawPIPView> with TickerProviderStateMixin {
                   final floatingOffset = _isDragging
                       ? _dragOffset
                       : Tween<Offset>(
-                          begin: _dragOffset,
-                          end: calculatedOffset,
-                        ).transform(_dragAnimationController.isAnimating
-                          ? dragAnimationValue
-                          : toggleFloatingAnimationValue);
+                    begin: _dragOffset,
+                    end: calculatedOffset,
+                  ).transform(_dragAnimationController.isAnimating
+                      ? dragAnimationValue
+                      : toggleFloatingAnimationValue);
                   final borderRadius = Tween<double>(
                     begin: 0,
-                    end: 10,
+                    end: widget.floatingBorderRadius!,
                   ).transform(toggleFloatingAnimationValue);
                   final width = Tween<double>(
                     begin: fullWidgetSize.width,
@@ -287,9 +291,9 @@ PIPViewCorner _calculateNearestCorner({
   _CornerDistance calculateDistance(PIPViewCorner corner) {
     final distance = offsets[corner]!
         .translate(
-          -offset.dx,
-          -offset.dy,
-        )
+      -offset.dx,
+      -offset.dy,
+    )
         .distanceSquared;
     return _CornerDistance(
       corner: corner,


### PR DESCRIPTION
Add `floatingBorderRadius` member to both `RawPIPView` and `PIPView` classes.
Define a constant `defaultFloatingBorderRadius` and assign it to `RawPIPView`s floatingBorderRadius variable.